### PR TITLE
Fix Headset Detection and IRQ Bugs

### DIFF
--- a/Adafruit_TLV320DAC3100.h
+++ b/Adafruit_TLV320DAC3100.h
@@ -200,8 +200,8 @@ public:
 
   bool setHeadsetDetect(
       bool enable,
-      tlv320_detect_debounce_t detect_debounce = TLV320_DEBOUNCE_16MS,
-      tlv320_button_debounce_t button_debounce = TLV320_BTN_DEBOUNCE_0MS);
+      tlv320_detect_debounce_t detect_debounce = TLV320_DEBOUNCE_64MS,
+      tlv320_button_debounce_t button_debounce = TLV320_BTN_DEBOUNCE_16MS);
   tlv320_headset_status_t getHeadsetStatus(void);
 
   bool isBeeping(void);

--- a/examples/basicI2Sconfig/basicI2Sconfig.ino
+++ b/examples/basicI2Sconfig/basicI2Sconfig.ino
@@ -12,6 +12,11 @@ void halt(const char *message) {
 void setup() {
   Serial.begin(115200);
 
+  // Wait for serial connection before starting the demo
+  // Good for RP2040/2350 boards
+  while (!Serial)
+    delay(10);
+
   pinMode(TLV_RESET, OUTPUT);
   digitalWrite(TLV_RESET, LOW);
   delay(100);
@@ -91,13 +96,16 @@ void setup() {
     halt("Failed to configure speaker output!");
   }
 
+// Configure headset detection with recommended settings from TI.
   if (!codec.configMicBias(false, true, TLV320_MICBIAS_AVDD) ||
+      !codec.configDelayDivider(false) || // Must use internal clock for delay timer
       !codec.setHeadsetDetect(true) ||
       !codec.setInt1Source(true, true, false, false, false,
                            false) || // GPIO1 is detect headset or button press
       !codec.setGPIO1Mode(TLV320_GPIO1_INT1)) {
     halt("Failed to configure headset detect");
   }
+
   Serial.println("TLV config done!");
 }
 
@@ -112,7 +120,7 @@ void loop() {
       Serial.println("Headset removed");
       break;
     case TLV320_HEADSET_WITHOUT_MIC:
-      Serial.println("Headphones detected");
+      Serial.println("Headset detected");
       break;
     case TLV320_HEADSET_WITH_MIC:
       Serial.println("Headset with mic detected");

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TLV320 I2S
-version=1.0.0
+version=1.0.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the TLV320DAC3100 I2S DAC.


### PR DESCRIPTION
Hello!

I was trying to use the example sketch and it was unable to detect anything when headphones were plugged in and unplugged (or any other IRQ events). After checking my hardware with a scope and doing some research, [I ran into this discussion on the Texas Instruments forum](https://e2e.ti.com/support/audio-group/audio/f/audio-forum/1288714/tlv320dac3100-unable-to-get-jack-interrupt-on-headphone-insertion/.)

Though the posts are not too descriptive, it turns out that the IC has to use its own internal clock signal with its delay timer for the IRQ debounce logic to work reliably. With the debounce broken, the IRQ interrupts did not get triggered at all.

[As outlined in the data sheet register map](https://www.ti.com/lit/gpn/tlv320dac3100#page=86), this is done by setting bit `7` of the register `0x10` at `Page 3` to `0`. This library already has a function implemented to do this! So I just added the following to the example sketch to do so.

`codec.configDelayDivider(false) `

This fixed the issue with IRQ getting triggered, but random flags were constantly getting falsely triggered without any changes to the hardware state. So I increased default headset button-press and insertion debounce times in the library source to make it reliable and stop the constant serial monitor messages.

I tested this on a second-batch Fruit Jam board and it seems to be working without any issues. I really hope this has been helpful, and I would love to help out more if you have anything else in the backlog for this library. Thank you so much for your time :)

P.S.
I was also considering the following when implementing this but did not want to because they felt too invasive for a library that seems to be low-level to this extent. Either way, I would love to hear your opinions and can implement these if you would like.
* Make `setHeadsetDetect(true)` set the register once it's called or...
* Make `setHeadsetDetect(true)` return `false` and fail if the register value wasn't configured properly


